### PR TITLE
Use Hosted Github Emojis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-downloader.sh
 emojis.json
-preprocessor.sh
+preprocessor.sed
 emojis

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # GitHub emojis for Marked 2
 
 [Marked 2](http://marked2app.com/) is a great markdown previewer and it works
-really well with GitHub styles.  
-It does not display GitHub emojis though.  
-This repo contains a preprocessor to add support for emojis, so you can write
+really well with GitHub styles. However, it does not display GitHub emojis. This
+repo contains a preprocessor to add support for emojis, so you can write
 `:octocat:` in your code and see an emoji in previewer.
 
 ![](marked-emojis.png)
@@ -11,27 +10,26 @@ This repo contains a preprocessor to add support for emojis, so you can write
 ## Install
 
 1. Download [zip file](https://github.com/tonyganch/marked-emojis/releases/download/v1.0/marked-emojis.zip). It contains emojis from GitHub and a preprocessor file.
-1. In Marked 2 application open "Preferences" -> "Advanced" -> "Preprocessor".
-1. Check "Enable Custom Preprocessor".
-1. In "Path" field type in path to `preprocessor.sh` file inside downloaded
-folder from step 1.
-1. Done.
+2. In Marked 2 application open "Preferences" -> "Advanced" -> "Preprocessor".
+3. Check "Enable Custom Preprocessor".
+4. In "Path" field type in path to `preprocessor.sh` file inside downloaded
+   folder from step 1.
+5. Done.
 
 ## Build
 
 You can build and download all files yourself.
 
 1. Clone the repo.
-1. Run `build.sh` file. It will download emojis from GitHub and build
-a preprocessor file. Please note that downloading may take some time.
-1. In Marked 2 application open "Preferences" -> "Advanced" -> "Preprocessor".
-1. Check "Enable Custom Preprocessor".
-1. In "Path" field type in path to `preprocessor.sh` file inside the repo.
-1. Done.
+2. Run `build.sh` file. It will create a `sed` script to replace the latest Github emojis in your documents.
+3. In Marked 2 application open "Preferences" -> "Advanced" -> "Preprocessor".
+4. Check "Enable Custom Preprocessor".
+5. In "Path" field type in path to `preprocessor.sh` file inside the repo.
+6. Done.
 
 ## Issues
 
 1. Preprocessor is not smart enough so it will show emojis inside code blocks
-too.
-1. Preprocessor uses `sed` command for replacement so it must be present on your
-computer.
+   too.
+2. Preprocessor uses `sed` command for replacement so it must be present on your
+   computer.

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl https://api.github.com/emojis > emojis.json && ./scripts-maker.js && bash downloader.sh
+curl https://api.github.com/emojis > emojis.json && ./scripts-maker.js

--- a/preprocessor.sh
+++ b/preprocessor.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+sed -f "${SCRIPT_DIR}/preprocessor.sed" $@

--- a/scripts-maker.js
+++ b/scripts-maker.js
@@ -1,43 +1,42 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var emojis = require('./emojis.json');
+// Requires
+////////////////////////////////////////////////////////////////////
 
-var PREPROCESSOR_FILE = 'preprocessor.sh';
-var DOWNLOADER_FILE = 'downloader.sh';
+const fs = require("fs");
+const emojis = require("./emojis.json");
 
-var preprocessorData = ['#!/bin/bash', 'sed \''];
-var downloaderData = ['#!/bin/bash', 'rm -rf emojis', 'mkdir emojis'];
+// Working variables
+////////////////////////////////////////////////////////////////////
 
-for (var emoji in emojis) {
-  var url = emojis[emoji];
-  var filename = getFilenameFromUrl(url);
+const PREPROCESSOR_FILE = "preprocessor.sed";
+const preprocessorData = [];
 
-  addDataToPreprocessor(emoji, filename);
-  addDataToDownloader(url, filename);
-}
-
-preprocessorData.push('    \'');
-
-fs.writeFileSync(PREPROCESSOR_FILE, preprocessorData.join('\n'));
-fs.writeFileSync(DOWNLOADER_FILE, downloaderData.join('\n'));
+// Helper functions
+////////////////////////////////////////////////////////////////////
 
 function escape(str) {
-  return str.replace(/\//g, '\\/');
+  return str.replace(/\//g, "\\/");
 }
 
-function getFilenameFromUrl(url) {
-  return url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('?'));
-}
-
-function addDataToPreprocessor(emoji, filename) {
-  var src = escape(__dirname + '/emojis/' + filename);
-  var string = '     s/:' + emoji +
-      ':/<img style="height:20px;vertical-align:middle;" src="' + src + '">/g;';
+function addDataToPreprocessor(emoji, url) {
+  var src = escape(url);
+  var string =
+    "s/:" +
+    emoji +
+    ':/<img style="height:1em;vertical-align:middle;" src="' +
+    src +
+    '">/g;';
   preprocessorData.push(string);
 }
 
-function addDataToDownloader(url, filename) {
-  var string = 'curl ' + url + ' > emojis/' + filename;
-  downloaderData.push(string);
+// Execute script
+////////////////////////////////////////////////////////////////////
+
+for (var emoji in emojis) {
+  var url = emojis[emoji];
+
+  addDataToPreprocessor(emoji, url);
 }
+
+fs.writeFileSync(PREPROCESSOR_FILE, preprocessorData.join("\n"));


### PR DESCRIPTION
- Removing the download process in favor of linking to the github emojis directly.
- Moved sed commands into a separate file as the number of emojis supported creates an argument list that's too long for sed to handle.
- Added preprocessor.sh and removed from gitignore as this is now a standard, non-changing file.